### PR TITLE
Deployment fixes

### DIFF
--- a/config.template
+++ b/config.template
@@ -8,10 +8,10 @@ STACK_NAME_SUFFIX=""
 DEPLOY_ASSETS_MODULE="No"
 
 # The S3 bucket to hold Sniffles resources.
-# Used for the Slack lambda.
+# Used for the lambda uploads.
 RESOURCES_S3_BUCKET=""
 
-# The S3 key where to find the Slack lambda in the resources S3 bucket.
+# The S3 key where to find the Core lambda in the resources S3 bucket.
 # Leave empty to not deploy the core lambda
 CORE_LAMBDA_S3_KEY=""
 

--- a/config.template
+++ b/config.template
@@ -37,7 +37,7 @@ EXISTING_SNS=""
 
 # Log groups that match these patterns will get auto subscribed to Sniffles.
 # Leave empty to not upload a log group whitelist.
-# It's a comma separated string, e.g. ^/aws/lambda/.*-prod.*$
+# It's a comma separated string, e.g. ^/aws/lambda/.*-prod-.*$
 LOG_GROUPS_WHITELIST=""
 
 # Where in Systems Manager Parameter Store the log group whitelist patterns are stored.

--- a/config.template
+++ b/config.template
@@ -11,6 +11,9 @@ DEPLOY_ASSETS_MODULE="No"
 # Used for the lambda uploads.
 RESOURCES_S3_BUCKET=""
 
+# If Yes, the deployment will not attempt to create a new S3 bucket.
+USE_EXISTING_S3_BUCKET="No"
+
 # The S3 key where to find the Core lambda in the resources S3 bucket.
 # Leave empty to not deploy the core lambda
 CORE_LAMBDA_S3_KEY=""

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -41,6 +41,10 @@ if [ "$DEPLOY_ASSETS_MODULE" = "Yes" ]; then
     --no-fail-on-empty-changeset \
     --tags Project="$PROJECT" ProjectKey="$PROJECT_KEY" Account=$(aws sts get-caller-identity | jq -r '.Account') Environment="$ENVIRONMENT" CostCenter="$PROJECT" SetupRequest="$SETUP_REQUEST" SLA="$SLA" ManagedBy=cloudformation Repo=https://github.com/enfogroup/sniffles/
 
+  export RESOURCES_S3_BUCKET=$RESOURCES_S3_BUCKET
+  export CORE_LAMBDA_S3_KEY=$CORE_LAMBDA_S3_KEY
+  export SLACK_LAMBDA_S3_KEY=$SLACK_LAMBDA_S3_KEY
+
   echo "Building core lambda..."
   cd core-lambda
   yarn install

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -33,14 +33,16 @@ EXISTING_KINESIS=""
 ###
 
 if [ "$DEPLOY_ASSETS_MODULE" = "Yes" ]; then
-  echo "Deploying assets..."
-  aws cloudformation deploy \
-    --stack-name "$FULL_STACK_NAME_ASSETS" \
-    --template-file ./cloudformation-templates/assets.yml \
-    --parameter-overrides BucketName="$RESOURCES_S3_BUCKET" \
-    --no-fail-on-empty-changeset \
-    --tags Project="$PROJECT" ProjectKey="$PROJECT_KEY" Account=$(aws sts get-caller-identity | jq -r '.Account') Environment="$ENVIRONMENT" CostCenter="$PROJECT" SetupRequest="$SETUP_REQUEST" SLA="$SLA" ManagedBy=cloudformation Repo=https://github.com/enfogroup/sniffles/
+  if [ "$USE_EXISTING_S3_BUCKET" != "Yes" ]; then
+    aws cloudformation deploy \
+      --stack-name "$FULL_STACK_NAME_ASSETS" \
+      --template-file ./cloudformation-templates/assets.yml \
+      --parameter-overrides BucketName="$RESOURCES_S3_BUCKET" \
+      --no-fail-on-empty-changeset \
+      --tags Project="$PROJECT" ProjectKey="$PROJECT_KEY" Account=$(aws sts get-caller-identity | jq -r '.Account') Environment="$ENVIRONMENT" CostCenter="$PROJECT" SetupRequest="$SETUP_REQUEST" SLA="$SLA" ManagedBy=cloudformation Repo=https://github.com/enfogroup/sniffles/
+  fi
 
+  echo "Deploying assets..."
   export RESOURCES_S3_BUCKET=$RESOURCES_S3_BUCKET
   export CORE_LAMBDA_S3_KEY=$CORE_LAMBDA_S3_KEY
   export SLACK_LAMBDA_S3_KEY=$SLACK_LAMBDA_S3_KEY

--- a/examples/more-complex-example/config-downstream.template
+++ b/examples/more-complex-example/config-downstream.template
@@ -11,6 +11,9 @@ DEPLOY_ASSETS_MODULE="No"
 # Used for the Slack lambda.
 RESOURCES_S3_BUCKET="[VALUE]"
 
+# If Yes, the deployment will not attempt to create a new S3 bucket.
+USE_EXISTING_S3_BUCKET="No"
+
 # The S3 key where to find the Slack lambda in the resources S3 bucket.
 # Leave empty to not deploy the core lambda
 CORE_LAMBDA_S3_KEY=""

--- a/examples/more-complex-example/config-env1.template
+++ b/examples/more-complex-example/config-env1.template
@@ -11,6 +11,9 @@ DEPLOY_ASSETS_MODULE="No"
 # Used for the Slack lambda.
 RESOURCES_S3_BUCKET="[VALUE]"
 
+# If Yes, the deployment will not attempt to create a new S3 bucket.
+USE_EXISTING_S3_BUCKET="No"
+
 # The S3 key where to find the Slack lambda in the resources S3 bucket.
 # Leave empty to not deploy the core lambda
 CORE_LAMBDA_S3_KEY="[VALUE]"

--- a/examples/more-complex-example/config-env2.template
+++ b/examples/more-complex-example/config-env2.template
@@ -11,6 +11,9 @@ DEPLOY_ASSETS_MODULE="No"
 # Used for the Slack lambda.
 RESOURCES_S3_BUCKET="[VALUE]"
 
+# If Yes, the deployment will not attempt to create a new S3 bucket.
+USE_EXISTING_S3_BUCKET="No"
+
 # The S3 key where to find the Slack lambda in the resources S3 bucket.
 # Leave empty to not deploy the core lambda
 CORE_LAMBDA_S3_KEY="[VALUE]"

--- a/examples/only-cloudwatch-monitoring/config-cloudwatch.template
+++ b/examples/only-cloudwatch-monitoring/config-cloudwatch.template
@@ -11,6 +11,9 @@ DEPLOY_ASSETS_MODULE="No"
 # Used for the Slack lambda.
 RESOURCES_S3_BUCKET=""
 
+# If Yes, the deployment will not attempt to create a new S3 bucket.
+USE_EXISTING_S3_BUCKET="No"
+
 # The S3 key where to find the Slack lambda in the resources S3 bucket.
 # Leave empty to not deploy the core lambda
 CORE_LAMBDA_S3_KEY=""


### PR DESCRIPTION
- Added support for users to decide if they want to use an existing bucket or create one
- Fixed full deployment flow issue by exporting variables. Works on Mac at least
- Fixed typo for core lambda
- Updated description of LOG_GROUPS_WHITELIST. ^/aws/lambda/.*-prod.*$ could match "/aws/lambda/my-stage-test-products" by accident.